### PR TITLE
Fix some missing dependency declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,8 +114,7 @@
     "@babel/helper-plugin-utils": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-      "dev": true
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
     },
     "@babel/helper-replace-supers": {
       "version": "7.8.6",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,14 @@
     "url": "https://github.com/karlprieb/babel-plugin-add-import-extension/issues"
   },
   "homepage": "https://github.com/karlprieb/babel-plugin-add-import-extension#readme",
+  "peerDependencies": {
+    "@babel/core": ">=7.0.0"
+  },
+  "dependencies": {
+    "@babel/helper-plugin-utils": "^7.8.3"
+  },
   "devDependencies": {
     "@babel/core": "^7.9.0",
-    "@babel/helper-plugin-utils": "^7.8.3",
     "jest": "^25.1.0"
   }
 }


### PR DESCRIPTION
Hey @karlprieb 

Friendly notice you have missed declarations in package.json for some babel dependencies

1. @babel/core should be in peerDeps
2. @babel/helper-plugin-utils should be dependencies instead of devDependencies because the plugin directly uses it in code.

```
Error: babel-plugin-add-import-extension tried to access @babel/helper-plugin-utils, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @babel/helper-plugin-utils (via "@babel/helper-plugin-utils")
Required by: babel-plugin-add-import-extension@npm:1.3.1 (via /home/cometkim/Workspace/src/github.com/cometkim/cometjs/.yarn/cache/babel-plugin-add-import-extension-npm-1.3.1-c947350b73-2.zip/node_modules/babel-plugin-add-import-extension/src/)
```