### PR TITLE
feat: skip type-only imports and exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-add-import-extension",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -278,6 +278,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.1.tgz",
+      "integrity": "sha512-X/d8glkrAtra7CaQGMiGs/OGa6XgUzqPcBXCIGFCpCqnfGlT0Wfbzo/B89xHhnInTaItPK8LALblVXcUOEh95Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/template": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",
+    "@babel/plugin-syntax-typescript": "^7.10.1",
     "jest": "^26.1.0"
   }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -27,9 +27,12 @@ const skipModule = (module, { replace, extension }) =>
 const makeDeclaration =
   ({ declaration, args, replace = false, extension = 'js' }) =>
       (path, { file: { opts: { filename } }}) => {
-        const { node: { source } } = path
+        const { node } = path
+        const { source, exportKind, importKind } = node
 
-        if (!source || skipModule(source && source.value, { replace, extension })) return
+        const isTypeOnly = exportKind === 'type' || importKind === 'type'
+
+        if (!source || isTypeOnly || skipModule(source && source.value, { replace, extension })) return
         const { value: module } = source
 
         const dirPath = resolve(dirname(filename), module)

--- a/tests/__snapshots__/test.js.snap
+++ b/tests/__snapshots__/test.js.snap
@@ -111,3 +111,19 @@ import replacer_anotherImport from \\"./lib/something.js\\";
 import replacer_another, { replacer_otherImport } from \\"./lib/something.js\\";
 import * as replacer_Something from \\"./lib/something.js\\";"
 `;
+
+exports[`Replace should skip type-only exports 1`] = `"export type { NamedType } from './lib/something';"`;
+
+exports[`Replace should skip type-only exports 2`] = `"export type { NamedType } from './lib/something';"`;
+
+exports[`Replace should skip type-only imports 1`] = `
+"import type DefaultType from './lib/something';
+import type { NamedType } from './lib/something';
+import type * as AllTypes from './lib/something';"
+`;
+
+exports[`Replace should skip type-only imports 2`] = `
+"import type DefaultType from './lib/something';
+import type { NamedType } from './lib/something';
+import type * as AllTypes from './lib/something';"
+`;


### PR DESCRIPTION
This fixes #10 

I tried this in my project and worked fine. Unfortunately I don't know what changes are necessary to get the jest test to pass. 

As of `7.9` (babel/babel#11171) this should be supported but somehow the parser keeps complaining about the syntax