### PR TITLE
fix: don't exclude relative paths

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,7 +4,7 @@ const { existsSync, lstatSync } = require('fs')
 const { resolve, extname, dirname } = require('path')
 
 const isNodeModule = module => {
-  if (module === '../') {
+  if (module.startsWith('.') || module.startsWith('/')) {
     return false
   }
 

--- a/tests/__snapshots__/test.js.snap
+++ b/tests/__snapshots__/test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`Replace should add the custom extension to export statements 1`] = `
 "export { oneBackLevel } from \\"../index.jsx\\";
+export { oneBackLevelIndex } from \\"../index.jsx\\";
 export { twoBackLevel } from \\"../../index.jsx\\";
+export { twoBackLevelIndex } from \\"../../index.jsx\\";
 export { somethingBack } from \\"../lib/something.jsx\\";
 export { something } from \\"./lib/something.jsx\\";
 export { something as another } from \\"./lib/something.jsx\\";
@@ -17,7 +19,9 @@ export * as replacer_something2 from './lib/something.ts';"
 
 exports[`Replace should add the custom extension to import statements 1`] = `
 "import { oneBackLevel } from \\"../index.jsx\\";
+import { oneBackLevelIndex } from \\"../index.jsx\\";
 import { twoBackLevel } from \\"../../index.jsx\\";
+import { twoBackLevelIndex } from \\"../../index.jsx\\";
 import { somethingBack } from \\"../lib/something.jsx\\";
 import { export1, export2 as alias2 } from \\"./lib/something.jsx\\";
 import { something } from \\"./lib/something.jsx\\";
@@ -36,7 +40,9 @@ import * as replacer_Something from './lib/something.ts';"
 
 exports[`Replace should add the default extension to export statements 1`] = `
 "export { oneBackLevel } from \\"../index.js\\";
+export { oneBackLevelIndex } from \\"../index.js\\";
 export { twoBackLevel } from \\"../../index.js\\";
+export { twoBackLevelIndex } from \\"../../index.js\\";
 export { somethingBack } from \\"../lib/something.js\\";
 export { something } from \\"./lib/something.js\\";
 export { something as another } from \\"./lib/something.js\\";
@@ -51,7 +57,9 @@ export * as replacer_something2 from './lib/something.ts';"
 
 exports[`Replace should add the default extension to import statements 1`] = `
 "import { oneBackLevel } from \\"../index.js\\";
+import { oneBackLevelIndex } from \\"../index.js\\";
 import { twoBackLevel } from \\"../../index.js\\";
+import { twoBackLevelIndex } from \\"../../index.js\\";
 import { somethingBack } from \\"../lib/something.js\\";
 import { export1, export2 as alias2 } from \\"./lib/something.js\\";
 import { something } from \\"./lib/something.js\\";
@@ -70,7 +78,9 @@ import * as replacer_Something from './lib/something.ts';"
 
 exports[`Replace should add the replace custom extension to export statements 1`] = `
 "export { oneBackLevel } from \\"../index.jsx\\";
+export { oneBackLevelIndex } from \\"../index.jsx\\";
 export { twoBackLevel } from \\"../../index.jsx\\";
+export { twoBackLevelIndex } from \\"../../index.jsx\\";
 export { somethingBack } from \\"../lib/something.jsx\\";
 export { something } from \\"./lib/something.jsx\\";
 export { something as another } from \\"./lib/something.jsx\\";
@@ -85,7 +95,9 @@ export * as replacer_something2 from \\"./lib/something.jsx\\";"
 
 exports[`Replace should add the replace custom extension to import statements 1`] = `
 "import { oneBackLevel } from \\"../index.jsx\\";
+import { oneBackLevelIndex } from \\"../index.jsx\\";
 import { twoBackLevel } from \\"../../index.jsx\\";
+import { twoBackLevelIndex } from \\"../../index.jsx\\";
 import { somethingBack } from \\"../lib/something.jsx\\";
 import { export1, export2 as alias2 } from \\"./lib/something.jsx\\";
 import { something } from \\"./lib/something.jsx\\";
@@ -104,7 +116,9 @@ import * as replacer_Something from \\"./lib/something.jsx\\";"
 
 exports[`Replace should add the replace default extension to export statements 1`] = `
 "export { oneBackLevel } from \\"../index.js\\";
+export { oneBackLevelIndex } from \\"../index.js\\";
 export { twoBackLevel } from \\"../../index.js\\";
+export { twoBackLevelIndex } from \\"../../index.js\\";
 export { somethingBack } from \\"../lib/something.js\\";
 export { something } from \\"./lib/something.js\\";
 export { something as another } from \\"./lib/something.js\\";
@@ -119,7 +133,9 @@ export * as replacer_something2 from \\"./lib/something.js\\";"
 
 exports[`Replace should add the replace default extension to import statements 1`] = `
 "import { oneBackLevel } from \\"../index.js\\";
+import { oneBackLevelIndex } from \\"../index.js\\";
 import { twoBackLevel } from \\"../../index.js\\";
+import { twoBackLevelIndex } from \\"../../index.js\\";
 import { somethingBack } from \\"../lib/something.js\\";
 import { export1, export2 as alias2 } from \\"./lib/something.js\\";
 import { something } from \\"./lib/something.js\\";

--- a/tests/test.js
+++ b/tests/test.js
@@ -4,8 +4,10 @@ const syntaxTypescript = require('@babel/plugin-syntax-typescript')
 const plugin = require('../src/plugin.js')
 
 const importStatements = `
-import { oneBackLevel } from '../'
+import { oneBackLevel } from '..'
+import { oneBackLevelIndex } from '../'
 import { twoBackLevel } from '../..'
+import { twoBackLevelIndex } from '../../'
 import { somethingBack } from '../lib/something'
 import { export1 , export2 as alias2 } from './lib/something'
 import { something } from './lib/something'
@@ -24,8 +26,10 @@ import * as replacer_Something from './lib/something.ts'
 `
 
 const exportStatements = `
-export { oneBackLevel } from '../'
-export { twoBackLevel } from '../../'
+export { oneBackLevel } from '..'
+export { oneBackLevelIndex } from '../'
+export { twoBackLevel } from '../..'
+export { twoBackLevelIndex } from '../../'
 export { somethingBack } from '../lib/something'
 export { something } from './lib/something'
 export { something as another } from './lib/something'
@@ -44,9 +48,9 @@ export type { NamedType } from './lib/something'
 `
 
 const typeOnlyImports = `
-import type DefaultType from './lib/something' 
-import type { NamedType } from './lib/something' 
-import type * as AllTypes from './lib/something' 
+import type DefaultType from './lib/something'
+import type { NamedType } from './lib/something'
+import type * as AllTypes from './lib/something'
 `
 
 describe('Replace', () => {


### PR DESCRIPTION
Trying to import `../../util` caused `isNodeModule` to return true if the `util` package is installed, even though it's supposed to resolve to `src/util`. I couldn't really add a proper test case for this as it requires some directories to exist on disc, but I tested the change in my project and it now resolves correctly. 