### PR TITLE
Allow plugin to handle complex file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ by changing the `observedScriptExtensions` option
 
 ```js
 plugins: [
-  ["babel-plugin-add-import-extension", { extension: "jsx", replace: true, observedScriptExtensions: ['js','ts','jsx','tsx'] }], // will add jsx extension
+  ["babel-plugin-add-import-extension", { extension: "jsx", replace: true, observedScriptExtensions: ['js','ts','jsx','tsx', 'mjs', 'cjs'] }], // will add jsx extension
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,17 @@ You can also replace existing extensions with the one you want
 
 ```js
 plugins: [
-  ["babel-plugin-add-import-extension", { extension: "jsx", replace: true }], // will add jsx extension
+  ["babel-plugin-add-import-extension", { extension: "jsx", replace: true }], // will replace the "observedScriptExtensions" [see below] to jsx
+];
+```
+
+To be able to handle file with a *.* in the filename (e.g *component.style.ts*) the plugin is configured
+to only handle a certain set of file extensions. If needed you can adjust the default of `['js','ts','jsx','tsx']` 
+by changing the `observedScriptExtensions` option
+
+```js
+plugins: [
+  ["babel-plugin-add-import-extension", { extension: "jsx", replace: true, observedScriptExtensions: ['js','ts','jsx','tsx'] }], // will add jsx extension
 ];
 ```
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,7 +4,7 @@ const { existsSync, lstatSync } = require('fs')
 const { resolve, extname, dirname } = require('path')
 
 const isActiveExtension = (module, observedScriptExtensions) =>
-  observedScriptExtensions.indexOf(extname(module).replace(/[^a-z]/,'')) > -1
+  observedScriptExtensions.indexOf(extname(module).replace(/[^a-z]/, '')) > -1
 
 const isNodeModule = module => {
   if (module.startsWith('.') || module.startsWith('/')) {
@@ -28,27 +28,25 @@ const skipModule = (module, { replace, extension, observedScriptExtensions }) =>
   (
     replace && (isActiveExtension(module, observedScriptExtensions) || extname(module) === `.${extension}`)
       ? extname(module) === `.${extension}`
-      : extname(module).length 
-        && (isActiveExtension(module, observedScriptExtensions) || extname(module) === `.${extension}`)
-        && extname(module) === `.${extension}`
+      : extname(module).length &&
+        (isActiveExtension(module, observedScriptExtensions) || extname(module) === `.${extension}`) &&
+        extname(module) === `.${extension}`
   )
 
 const makeDeclaration =
-  ({ declaration, args, replace = false, extension = 'js', observedScriptExtensions = ['js','ts','jsx','tsx'] }) =>
+  ({ declaration, args, replace = false, extension = 'js', observedScriptExtensions = ['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs'] }) =>
     (path, { file: { opts: { filename } } }) => {
       const { node } = path
       const { source, exportKind, importKind } = node
 
       const isTypeOnly = exportKind === 'type' || importKind === 'type'
 
-      if (!source || isTypeOnly)
-        return;
+      if (!source || isTypeOnly) { return }
 
-      const module = source && source.value;
+      const module = source && source.value
 
-      if (skipModule(module, { replace, extension, observedScriptExtensions }))
-        return
-      
+      if (skipModule(module, { replace, extension, observedScriptExtensions })) { return }
+
       const dirPath = resolve(dirname(filename), module)
 
       const hasModuleExt = extname(module).length && isActiveExtension(module, observedScriptExtensions)

--- a/tests/__snapshots__/test.js.snap
+++ b/tests/__snapshots__/test.js.snap
@@ -1,20 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Replace should add the custom extension to export not observed statements 1`] = `
+"export { oneBackLevel } from \\"../index.jsx\\";
+export { oneBackLevelIndex } from \\"../index.jsx\\";
+export { twoBackLevel } from \\"../../index.jsx\\";
+export { twoBackLevelIndex } from \\"../../index.jsx\\";
+export { somethingBack } from \\"../lib/something.jsx\\";
+export { somethingBackTest } from \\"../lib/something.test.jsx\\";
+export { something } from \\"./lib/something.jsx\\";
+export { somethingTest } from \\"./lib/something.test.jsx\\";
+export { something as another } from \\"./lib/something.jsx\\";
+export { somethingTest as anotherTest } from \\"./lib/something.test.jsx\\";
+export * as anotherModule from \\"./lib/something.jsx\\";
+export * as anotherModuleTest from \\"./lib/something.test.jsx\\";
+export * from \\"./lib/something.jsx\\";
+export * from \\"./lib/something.test.jsx\\";
+export { transform } from '@babel/core';
+export { replacer_something } from \\"./lib/something.jsx\\";
+export { replacer_somethingTest } from \\"./lib/something.test.jsx\\";
+export { replacer_something as replacer_another } from \\"./lib/something.jsx\\";
+export { replacer_something as replacer_anotherTest } from \\"./lib/something.test.jsx\\";
+export * as replacer_anotherModule from \\"./lib/something.jsx\\";
+export * as replacer_anotherModuleTest from \\"./lib/something.test.jsx\\";
+export * as replacer_something2 from \\"./lib/something.jsx\\";
+export * as replacer_something2Test from \\"./lib/something.test.jsx\\";"
+`;
+
 exports[`Replace should add the custom extension to export statements 1`] = `
 "export { oneBackLevel } from \\"../index.jsx\\";
 export { oneBackLevelIndex } from \\"../index.jsx\\";
 export { twoBackLevel } from \\"../../index.jsx\\";
 export { twoBackLevelIndex } from \\"../../index.jsx\\";
 export { somethingBack } from \\"../lib/something.jsx\\";
+export { somethingBackTest } from \\"../lib/something.test.jsx\\";
 export { something } from \\"./lib/something.jsx\\";
+export { somethingTest } from \\"./lib/something.test.jsx\\";
 export { something as another } from \\"./lib/something.jsx\\";
+export { somethingTest as anotherTest } from \\"./lib/something.test.jsx\\";
 export * as anotherModule from \\"./lib/something.jsx\\";
+export * as anotherModuleTest from \\"./lib/something.test.jsx\\";
 export * from \\"./lib/something.jsx\\";
+export * from \\"./lib/something.test.jsx\\";
 export { transform } from '@babel/core';
-export { replacer_something } from './lib/something.ts';
-export { replacer_something as replacer_another } from './lib/something.ts';
-export * as replacer_anotherModule from './lib/something.ts';
-export * as replacer_something2 from './lib/something.ts';"
+export { replacer_something } from \\"./lib/something.jsx\\";
+export { replacer_somethingTest } from \\"./lib/something.test.jsx\\";
+export { replacer_something as replacer_another } from \\"./lib/something.jsx\\";
+export { replacer_something as replacer_anotherTest } from \\"./lib/something.test.jsx\\";
+export * as replacer_anotherModule from \\"./lib/something.jsx\\";
+export * as replacer_anotherModuleTest from \\"./lib/something.test.jsx\\";
+export * as replacer_something2 from \\"./lib/something.jsx\\";
+export * as replacer_something2Test from \\"./lib/something.test.jsx\\";"
+`;
+
+exports[`Replace should add the custom extension to import not observed statements 1`] = `
+"import { oneBackLevel } from \\"../index.jsx\\";
+import { oneBackLevelIndex } from \\"../index.jsx\\";
+import { twoBackLevel } from \\"../../index.jsx\\";
+import { twoBackLevelIndex } from \\"../../index.jsx\\";
+import { somethingBack } from \\"../lib/something.jsx\\";
+import { somethingBackTest } from \\"../lib/something.test.jsx\\";
+import { export1, export2 as alias2 } from \\"./lib/something.jsx\\";
+import { export1Test, export2 as alias2Test } from \\"./lib/something.test.jsx\\";
+import { something } from \\"./lib/something.jsx\\";
+import { somethingTest } from \\"./lib/something.test.jsx\\";
+import { something as other } from \\"./lib/something.jsx\\";
+import { something as otherTest } from \\"./lib/something.test.jsx\\";
+import anotherImport from \\"./lib/something.jsx\\";
+import anotherImportTest from \\"./lib/something.test.jsx\\";
+import another, { otherImport } from \\"./lib/something.jsx\\";
+import anotherTest, { otherImportTest } from \\"./lib/something.test.jsx\\";
+import * as Something from \\"./lib/something.jsx\\";
+import * as SomethingTest from \\"./lib/something.test.jsx\\";
+import { transform } from '@babel/core';
+import { replacer_export1, replacer_export2 as replacer_alias2 } from \\"./lib/something.jsx\\";
+import { replacer_export1Test, replacer_export2 as replacer_alias2Test } from \\"./lib/something.test.jsx\\";
+import { replacer_something } from \\"./lib/something.jsx\\";
+import { replacer_somethingTest } from \\"./lib/something.test.jsx\\";
+import { replacer_something as replacer_other } from \\"./lib/something.jsx\\";
+import { replacer_something as replacer_otherTest } from \\"./lib/something.test.jsx\\";
+import replacer_anotherImport from \\"./lib/something.jsx\\";
+import replacer_anotherImportTest from \\"./lib/something.test.jsx\\";
+import replacer_another, { replacer_otherImport } from \\"./lib/something.jsx\\";
+import replacer_anotherTest, { replacer_otherImportTest } from \\"./lib/something.test.jsx\\";
+import * as replacer_Something from \\"./lib/something.jsx\\";
+import * as replacer_SomethingTest from \\"./lib/something.test.jsx\\";"
 `;
 
 exports[`Replace should add the custom extension to import statements 1`] = `
@@ -23,36 +92,32 @@ import { oneBackLevelIndex } from \\"../index.jsx\\";
 import { twoBackLevel } from \\"../../index.jsx\\";
 import { twoBackLevelIndex } from \\"../../index.jsx\\";
 import { somethingBack } from \\"../lib/something.jsx\\";
+import { somethingBackTest } from \\"../lib/something.test.jsx\\";
 import { export1, export2 as alias2 } from \\"./lib/something.jsx\\";
+import { export1Test, export2 as alias2Test } from \\"./lib/something.test.jsx\\";
 import { something } from \\"./lib/something.jsx\\";
+import { somethingTest } from \\"./lib/something.test.jsx\\";
 import { something as other } from \\"./lib/something.jsx\\";
+import { something as otherTest } from \\"./lib/something.test.jsx\\";
 import anotherImport from \\"./lib/something.jsx\\";
+import anotherImportTest from \\"./lib/something.test.jsx\\";
 import another, { otherImport } from \\"./lib/something.jsx\\";
+import anotherTest, { otherImportTest } from \\"./lib/something.test.jsx\\";
 import * as Something from \\"./lib/something.jsx\\";
+import * as SomethingTest from \\"./lib/something.test.jsx\\";
 import { transform } from '@babel/core';
-import { replacer_export1, replacer_export2 as replacer_alias2 } from './lib/something.ts';
-import { replacer_something } from './lib/something.ts';
-import { replacer_something as replacer_other } from './lib/something.ts';
-import replacer_anotherImport from './lib/something.ts';
-import replacer_another, { replacer_otherImport } from './lib/something.ts';
-import * as replacer_Something from './lib/something.ts';"
-`;
-
-exports[`Replace should add the default extension to export statements 1`] = `
-"export { oneBackLevel } from \\"../index.js\\";
-export { oneBackLevelIndex } from \\"../index.js\\";
-export { twoBackLevel } from \\"../../index.js\\";
-export { twoBackLevelIndex } from \\"../../index.js\\";
-export { somethingBack } from \\"../lib/something.js\\";
-export { something } from \\"./lib/something.js\\";
-export { something as another } from \\"./lib/something.js\\";
-export * as anotherModule from \\"./lib/something.js\\";
-export * from \\"./lib/something.js\\";
-export { transform } from '@babel/core';
-export { replacer_something } from './lib/something.ts';
-export { replacer_something as replacer_another } from './lib/something.ts';
-export * as replacer_anotherModule from './lib/something.ts';
-export * as replacer_something2 from './lib/something.ts';"
+import { replacer_export1, replacer_export2 as replacer_alias2 } from \\"./lib/something.jsx\\";
+import { replacer_export1Test, replacer_export2 as replacer_alias2Test } from \\"./lib/something.test.jsx\\";
+import { replacer_something } from \\"./lib/something.jsx\\";
+import { replacer_somethingTest } from \\"./lib/something.test.jsx\\";
+import { replacer_something as replacer_other } from \\"./lib/something.jsx\\";
+import { replacer_something as replacer_otherTest } from \\"./lib/something.test.jsx\\";
+import replacer_anotherImport from \\"./lib/something.jsx\\";
+import replacer_anotherImportTest from \\"./lib/something.test.jsx\\";
+import replacer_another, { replacer_otherImport } from \\"./lib/something.jsx\\";
+import replacer_anotherTest, { replacer_otherImportTest } from \\"./lib/something.test.jsx\\";
+import * as replacer_Something from \\"./lib/something.jsx\\";
+import * as replacer_SomethingTest from \\"./lib/something.test.jsx\\";"
 `;
 
 exports[`Replace should add the default extension to import statements 1`] = `
@@ -61,19 +126,58 @@ import { oneBackLevelIndex } from \\"../index.js\\";
 import { twoBackLevel } from \\"../../index.js\\";
 import { twoBackLevelIndex } from \\"../../index.js\\";
 import { somethingBack } from \\"../lib/something.js\\";
+import { somethingBackTest } from \\"../lib/something.test.js\\";
 import { export1, export2 as alias2 } from \\"./lib/something.js\\";
+import { export1Test, export2 as alias2Test } from \\"./lib/something.test.js\\";
 import { something } from \\"./lib/something.js\\";
+import { somethingTest } from \\"./lib/something.test.js\\";
 import { something as other } from \\"./lib/something.js\\";
+import { something as otherTest } from \\"./lib/something.test.js\\";
 import anotherImport from \\"./lib/something.js\\";
+import anotherImportTest from \\"./lib/something.test.js\\";
 import another, { otherImport } from \\"./lib/something.js\\";
+import anotherTest, { otherImportTest } from \\"./lib/something.test.js\\";
 import * as Something from \\"./lib/something.js\\";
+import * as SomethingTest from \\"./lib/something.test.js\\";
 import { transform } from '@babel/core';
-import { replacer_export1, replacer_export2 as replacer_alias2 } from './lib/something.ts';
-import { replacer_something } from './lib/something.ts';
-import { replacer_something as replacer_other } from './lib/something.ts';
-import replacer_anotherImport from './lib/something.ts';
-import replacer_another, { replacer_otherImport } from './lib/something.ts';
-import * as replacer_Something from './lib/something.ts';"
+import { replacer_export1, replacer_export2 as replacer_alias2 } from \\"./lib/something.js\\";
+import { replacer_export1Test, replacer_export2 as replacer_alias2Test } from \\"./lib/something.test.js\\";
+import { replacer_something } from \\"./lib/something.js\\";
+import { replacer_somethingTest } from \\"./lib/something.test.js\\";
+import { replacer_something as replacer_other } from \\"./lib/something.js\\";
+import { replacer_something as replacer_otherTest } from \\"./lib/something.test.js\\";
+import replacer_anotherImport from \\"./lib/something.js\\";
+import replacer_anotherImportTest from \\"./lib/something.test.js\\";
+import replacer_another, { replacer_otherImport } from \\"./lib/something.js\\";
+import replacer_anotherTest, { replacer_otherImportTest } from \\"./lib/something.test.js\\";
+import * as replacer_Something from \\"./lib/something.js\\";
+import * as replacer_SomethingTest from \\"./lib/something.test.js\\";"
+`;
+
+exports[`Replace should add the replace custom extension to export not observed statements 1`] = `
+"export { oneBackLevel } from \\"../index.jsx\\";
+export { oneBackLevelIndex } from \\"../index.jsx\\";
+export { twoBackLevel } from \\"../../index.jsx\\";
+export { twoBackLevelIndex } from \\"../../index.jsx\\";
+export { somethingBack } from \\"../lib/something.jsx\\";
+export { somethingBackTest } from \\"../lib/something.test.jsx\\";
+export { something } from \\"./lib/something.jsx\\";
+export { somethingTest } from \\"./lib/something.test.jsx\\";
+export { something as another } from \\"./lib/something.jsx\\";
+export { somethingTest as anotherTest } from \\"./lib/something.test.jsx\\";
+export * as anotherModule from \\"./lib/something.jsx\\";
+export * as anotherModuleTest from \\"./lib/something.test.jsx\\";
+export * from \\"./lib/something.jsx\\";
+export * from \\"./lib/something.test.jsx\\";
+export { transform } from '@babel/core';
+export { replacer_something } from \\"./lib/something.jsx\\";
+export { replacer_somethingTest } from \\"./lib/something.test.jsx\\";
+export { replacer_something as replacer_another } from \\"./lib/something.jsx\\";
+export { replacer_something as replacer_anotherTest } from \\"./lib/something.test.jsx\\";
+export * as replacer_anotherModule from \\"./lib/something.jsx\\";
+export * as replacer_anotherModuleTest from \\"./lib/something.test.jsx\\";
+export * as replacer_something2 from \\"./lib/something.jsx\\";
+export * as replacer_something2Test from \\"./lib/something.test.jsx\\";"
 `;
 
 exports[`Replace should add the replace custom extension to export statements 1`] = `
@@ -82,15 +186,58 @@ export { oneBackLevelIndex } from \\"../index.jsx\\";
 export { twoBackLevel } from \\"../../index.jsx\\";
 export { twoBackLevelIndex } from \\"../../index.jsx\\";
 export { somethingBack } from \\"../lib/something.jsx\\";
+export { somethingBackTest } from \\"../lib/something.test.jsx\\";
 export { something } from \\"./lib/something.jsx\\";
+export { somethingTest } from \\"./lib/something.test.jsx\\";
 export { something as another } from \\"./lib/something.jsx\\";
+export { somethingTest as anotherTest } from \\"./lib/something.test.jsx\\";
 export * as anotherModule from \\"./lib/something.jsx\\";
+export * as anotherModuleTest from \\"./lib/something.test.jsx\\";
 export * from \\"./lib/something.jsx\\";
+export * from \\"./lib/something.test.jsx\\";
 export { transform } from '@babel/core';
 export { replacer_something } from \\"./lib/something.jsx\\";
+export { replacer_somethingTest } from \\"./lib/something.test.jsx\\";
 export { replacer_something as replacer_another } from \\"./lib/something.jsx\\";
+export { replacer_something as replacer_anotherTest } from \\"./lib/something.test.jsx\\";
 export * as replacer_anotherModule from \\"./lib/something.jsx\\";
-export * as replacer_something2 from \\"./lib/something.jsx\\";"
+export * as replacer_anotherModuleTest from \\"./lib/something.test.jsx\\";
+export * as replacer_something2 from \\"./lib/something.jsx\\";
+export * as replacer_something2Test from \\"./lib/something.test.jsx\\";"
+`;
+
+exports[`Replace should add the replace custom extension to import not observed statements 1`] = `
+"import { oneBackLevel } from \\"../index.jsx\\";
+import { oneBackLevelIndex } from \\"../index.jsx\\";
+import { twoBackLevel } from \\"../../index.jsx\\";
+import { twoBackLevelIndex } from \\"../../index.jsx\\";
+import { somethingBack } from \\"../lib/something.jsx\\";
+import { somethingBackTest } from \\"../lib/something.test.jsx\\";
+import { export1, export2 as alias2 } from \\"./lib/something.jsx\\";
+import { export1Test, export2 as alias2Test } from \\"./lib/something.test.jsx\\";
+import { something } from \\"./lib/something.jsx\\";
+import { somethingTest } from \\"./lib/something.test.jsx\\";
+import { something as other } from \\"./lib/something.jsx\\";
+import { something as otherTest } from \\"./lib/something.test.jsx\\";
+import anotherImport from \\"./lib/something.jsx\\";
+import anotherImportTest from \\"./lib/something.test.jsx\\";
+import another, { otherImport } from \\"./lib/something.jsx\\";
+import anotherTest, { otherImportTest } from \\"./lib/something.test.jsx\\";
+import * as Something from \\"./lib/something.jsx\\";
+import * as SomethingTest from \\"./lib/something.test.jsx\\";
+import { transform } from '@babel/core';
+import { replacer_export1, replacer_export2 as replacer_alias2 } from \\"./lib/something.jsx\\";
+import { replacer_export1Test, replacer_export2 as replacer_alias2Test } from \\"./lib/something.test.jsx\\";
+import { replacer_something } from \\"./lib/something.jsx\\";
+import { replacer_somethingTest } from \\"./lib/something.test.jsx\\";
+import { replacer_something as replacer_other } from \\"./lib/something.jsx\\";
+import { replacer_something as replacer_otherTest } from \\"./lib/something.test.jsx\\";
+import replacer_anotherImport from \\"./lib/something.jsx\\";
+import replacer_anotherImportTest from \\"./lib/something.test.jsx\\";
+import replacer_another, { replacer_otherImport } from \\"./lib/something.jsx\\";
+import replacer_anotherTest, { replacer_otherImportTest } from \\"./lib/something.test.jsx\\";
+import * as replacer_Something from \\"./lib/something.jsx\\";
+import * as replacer_SomethingTest from \\"./lib/something.test.jsx\\";"
 `;
 
 exports[`Replace should add the replace custom extension to import statements 1`] = `
@@ -99,36 +246,32 @@ import { oneBackLevelIndex } from \\"../index.jsx\\";
 import { twoBackLevel } from \\"../../index.jsx\\";
 import { twoBackLevelIndex } from \\"../../index.jsx\\";
 import { somethingBack } from \\"../lib/something.jsx\\";
+import { somethingBackTest } from \\"../lib/something.test.jsx\\";
 import { export1, export2 as alias2 } from \\"./lib/something.jsx\\";
+import { export1Test, export2 as alias2Test } from \\"./lib/something.test.jsx\\";
 import { something } from \\"./lib/something.jsx\\";
+import { somethingTest } from \\"./lib/something.test.jsx\\";
 import { something as other } from \\"./lib/something.jsx\\";
+import { something as otherTest } from \\"./lib/something.test.jsx\\";
 import anotherImport from \\"./lib/something.jsx\\";
+import anotherImportTest from \\"./lib/something.test.jsx\\";
 import another, { otherImport } from \\"./lib/something.jsx\\";
+import anotherTest, { otherImportTest } from \\"./lib/something.test.jsx\\";
 import * as Something from \\"./lib/something.jsx\\";
+import * as SomethingTest from \\"./lib/something.test.jsx\\";
 import { transform } from '@babel/core';
 import { replacer_export1, replacer_export2 as replacer_alias2 } from \\"./lib/something.jsx\\";
+import { replacer_export1Test, replacer_export2 as replacer_alias2Test } from \\"./lib/something.test.jsx\\";
 import { replacer_something } from \\"./lib/something.jsx\\";
+import { replacer_somethingTest } from \\"./lib/something.test.jsx\\";
 import { replacer_something as replacer_other } from \\"./lib/something.jsx\\";
+import { replacer_something as replacer_otherTest } from \\"./lib/something.test.jsx\\";
 import replacer_anotherImport from \\"./lib/something.jsx\\";
+import replacer_anotherImportTest from \\"./lib/something.test.jsx\\";
 import replacer_another, { replacer_otherImport } from \\"./lib/something.jsx\\";
-import * as replacer_Something from \\"./lib/something.jsx\\";"
-`;
-
-exports[`Replace should add the replace default extension to export statements 1`] = `
-"export { oneBackLevel } from \\"../index.js\\";
-export { oneBackLevelIndex } from \\"../index.js\\";
-export { twoBackLevel } from \\"../../index.js\\";
-export { twoBackLevelIndex } from \\"../../index.js\\";
-export { somethingBack } from \\"../lib/something.js\\";
-export { something } from \\"./lib/something.js\\";
-export { something as another } from \\"./lib/something.js\\";
-export * as anotherModule from \\"./lib/something.js\\";
-export * from \\"./lib/something.js\\";
-export { transform } from '@babel/core';
-export { replacer_something } from \\"./lib/something.js\\";
-export { replacer_something as replacer_another } from \\"./lib/something.js\\";
-export * as replacer_anotherModule from \\"./lib/something.js\\";
-export * as replacer_something2 from \\"./lib/something.js\\";"
+import replacer_anotherTest, { replacer_otherImportTest } from \\"./lib/something.test.jsx\\";
+import * as replacer_Something from \\"./lib/something.jsx\\";
+import * as replacer_SomethingTest from \\"./lib/something.test.jsx\\";"
 `;
 
 exports[`Replace should add the replace default extension to import statements 1`] = `
@@ -137,33 +280,72 @@ import { oneBackLevelIndex } from \\"../index.js\\";
 import { twoBackLevel } from \\"../../index.js\\";
 import { twoBackLevelIndex } from \\"../../index.js\\";
 import { somethingBack } from \\"../lib/something.js\\";
+import { somethingBackTest } from \\"../lib/something.test.js\\";
 import { export1, export2 as alias2 } from \\"./lib/something.js\\";
+import { export1Test, export2 as alias2Test } from \\"./lib/something.test.js\\";
 import { something } from \\"./lib/something.js\\";
+import { somethingTest } from \\"./lib/something.test.js\\";
 import { something as other } from \\"./lib/something.js\\";
+import { something as otherTest } from \\"./lib/something.test.js\\";
 import anotherImport from \\"./lib/something.js\\";
+import anotherImportTest from \\"./lib/something.test.js\\";
 import another, { otherImport } from \\"./lib/something.js\\";
+import anotherTest, { otherImportTest } from \\"./lib/something.test.js\\";
 import * as Something from \\"./lib/something.js\\";
+import * as SomethingTest from \\"./lib/something.test.js\\";
 import { transform } from '@babel/core';
 import { replacer_export1, replacer_export2 as replacer_alias2 } from \\"./lib/something.js\\";
+import { replacer_export1Test, replacer_export2 as replacer_alias2Test } from \\"./lib/something.test.js\\";
 import { replacer_something } from \\"./lib/something.js\\";
+import { replacer_somethingTest } from \\"./lib/something.test.js\\";
 import { replacer_something as replacer_other } from \\"./lib/something.js\\";
+import { replacer_something as replacer_otherTest } from \\"./lib/something.test.js\\";
 import replacer_anotherImport from \\"./lib/something.js\\";
+import replacer_anotherImportTest from \\"./lib/something.test.js\\";
 import replacer_another, { replacer_otherImport } from \\"./lib/something.js\\";
-import * as replacer_Something from \\"./lib/something.js\\";"
+import replacer_anotherTest, { replacer_otherImportTest } from \\"./lib/something.test.js\\";
+import * as replacer_Something from \\"./lib/something.js\\";
+import * as replacer_SomethingTest from \\"./lib/something.test.js\\";"
 `;
 
-exports[`Replace should skip type-only exports 1`] = `"export type { NamedType } from './lib/something';"`;
+exports[`Replace should skip type-only exports 1`] = `
+"export type { NamedType } from './lib/something';
+export type { NamedTypeTest } from './lib/something.test';"
+`;
 
-exports[`Replace should skip type-only exports 2`] = `"export type { NamedType } from './lib/something';"`;
+exports[`Replace should skip type-only exports 2`] = `
+"export type { NamedType } from './lib/something';
+export type { NamedTypeTest } from './lib/something.test';"
+`;
+
+exports[`Replace should skip type-only exports not observed 1`] = `
+"export type { NamedType } from './lib/something';
+export type { NamedTypeTest } from './lib/something.test';"
+`;
 
 exports[`Replace should skip type-only imports 1`] = `
 "import type DefaultType from './lib/something';
+import type DefaultTypeTest from './lib/something.test';
 import type { NamedType } from './lib/something';
-import type * as AllTypes from './lib/something';"
+import type { NamedTypeTest } from './lib/something.test';
+import type * as AllTypes from './lib/something';
+import type * as AllTypesTest from './lib/something.test';"
 `;
 
 exports[`Replace should skip type-only imports 2`] = `
 "import type DefaultType from './lib/something';
+import type DefaultTypeTest from './lib/something.test';
 import type { NamedType } from './lib/something';
-import type * as AllTypes from './lib/something';"
+import type { NamedTypeTest } from './lib/something.test';
+import type * as AllTypes from './lib/something';
+import type * as AllTypesTest from './lib/something.test';"
+`;
+
+exports[`Replace should skip type-only imports not observed 1`] = `
+"import type DefaultType from './lib/something';
+import type DefaultTypeTest from './lib/something.test';
+import type { NamedType } from './lib/something';
+import type { NamedTypeTest } from './lib/something.test';
+import type * as AllTypes from './lib/something';
+import type * as AllTypesTest from './lib/something.test';"
 `;

--- a/tests/test.js
+++ b/tests/test.js
@@ -38,7 +38,6 @@ import * as replacer_Something from './lib/something.ts'
 import * as replacer_SomethingTest from './lib/something.test.ts'
 `
 
-
 const exportStatements = `
 export { oneBackLevel } from '..'
 export { oneBackLevelIndex } from '../'
@@ -83,16 +82,16 @@ import type * as AllTypesTest from './lib/something.test'
 describe('Replace', () => {
   test.each`
     type                                                  | statements          | extension    | replace      | observedScriptExtensions
-    ${'default extension to import'}                      | ${importStatements} | ${undefined} | ${undefined} | ${['js','ts','jsx','tsx']}
-    ${'custom extension to import'}                       | ${importStatements} | ${'jsx'}     | ${undefined} | ${['js','ts','jsx','tsx']}
-    ${'custom extension to import not observed'}          | ${importStatements} | ${'jsx'}     | ${undefined} | ${['js','ts','tsx']}
-    ${'custom extension to export'}                       | ${exportStatements} | ${'jsx'}     | ${undefined} | ${['js','ts','jsx','tsx']}
-    ${'custom extension to export not observed'}          | ${exportStatements} | ${'jsx'}     | ${undefined} | ${['js','ts','tsx']}
-    ${'replace default extension to import'}              | ${importStatements} | ${undefined} | ${true}      | ${['js','ts','jsx','tsx']}
-    ${'replace custom extension to import'}               | ${importStatements} | ${'jsx'}     | ${true}      | ${['js','ts','jsx','tsx']}
-    ${'replace custom extension to import not observed'}  | ${importStatements} | ${'jsx'}     | ${true}      | ${['js','ts','tsx']}
-    ${'replace custom extension to export'}               | ${exportStatements} | ${'jsx'}     | ${true}      | ${['js','ts','jsx','tsx']}
-    ${'replace custom extension to export not observed'}  | ${exportStatements} | ${'jsx'}     | ${true}      | ${['js','ts','tsx']}
+    ${'default extension to import'}                      | ${importStatements} | ${undefined} | ${undefined} | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'custom extension to import'}                       | ${importStatements} | ${'jsx'}     | ${undefined} | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'custom extension to import not observed'}          | ${importStatements} | ${'jsx'}     | ${undefined} | ${['js', 'ts', 'tsx', 'mjs', 'cjs']}
+    ${'custom extension to export'}                       | ${exportStatements} | ${'jsx'}     | ${undefined} | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'custom extension to export not observed'}          | ${exportStatements} | ${'jsx'}     | ${undefined} | ${['js', 'ts', 'tsx', 'mjs', 'cjs']}
+    ${'replace default extension to import'}              | ${importStatements} | ${undefined} | ${true}      | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'replace custom extension to import'}               | ${importStatements} | ${'jsx'}     | ${true}      | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'replace custom extension to import not observed'}  | ${importStatements} | ${'jsx'}     | ${true}      | ${['js', 'ts', 'tsx', 'mjs', 'cjs']}
+    ${'replace custom extension to export'}               | ${exportStatements} | ${'jsx'}     | ${true}      | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'replace custom extension to export not observed'}  | ${exportStatements} | ${'jsx'}     | ${true}      | ${['js', 'ts', 'tsx', 'mjs', 'cjs']}
   `('should add the $type statements', ({ statements, extension, replace, observedScriptExtensions }) => {
     const { code } = babel.transformSync(statements, {
       plugins: [[plugin, { extension, replace, observedScriptExtensions }]],
@@ -104,12 +103,12 @@ describe('Replace', () => {
 
   test.each`
     type                                      | statements         | extension    | replace       | observedScriptExtensions
-    ${'skip type-only imports'}               | ${typeOnlyImports} | ${undefined} | ${undefined}  | ${['js','ts','jsx','tsx']}
-    ${'skip type-only exports'}               | ${typeOnlyExports} | ${undefined} | ${true}       | ${['js','ts','jsx','tsx']}
-    ${'skip type-only imports'}               | ${typeOnlyImports} | ${'jsx'}     | ${undefined}  | ${['js','ts','jsx','tsx']}
-    ${'skip type-only imports not observed'}  | ${typeOnlyImports} | ${'jsx'}     | ${undefined}  | ${['js','ts','tsx']}
-    ${'skip type-only exports'}               | ${typeOnlyExports} | ${'jsx'}     | ${true}       | ${['js','ts','jsx','tsx']}
-    ${'skip type-only exports not observed'}  | ${typeOnlyExports} | ${'jsx'}     | ${true}       | ${['js','ts','tsx']}
+    ${'skip type-only imports'}               | ${typeOnlyImports} | ${undefined} | ${undefined}  | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'skip type-only exports'}               | ${typeOnlyExports} | ${undefined} | ${true}       | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'skip type-only imports'}               | ${typeOnlyImports} | ${'jsx'}     | ${undefined}  | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'skip type-only imports not observed'}  | ${typeOnlyImports} | ${'jsx'}     | ${undefined}  | ${['js', 'ts', 'tsx', 'mjs', 'cjs']}
+    ${'skip type-only exports'}               | ${typeOnlyExports} | ${'jsx'}     | ${true}       | ${['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs']}
+    ${'skip type-only exports not observed'}  | ${typeOnlyExports} | ${'jsx'}     | ${true}       | ${['js', 'ts', 'tsx', 'mjs', 'cjs']}
   `('should $type', ({ statements, extension, replace, observedScriptExtensions }) => {
     const { code } = babel.transformSync(statements, {
       plugins: [syntaxTypescript, [plugin, { extension, replace, observedScriptExtensions }]],

--- a/tests/test.js
+++ b/tests/test.js
@@ -9,21 +9,35 @@ import { oneBackLevelIndex } from '../'
 import { twoBackLevel } from '../..'
 import { twoBackLevelIndex } from '../../'
 import { somethingBack } from '../lib/something'
+import { somethingBackTest } from '../lib/something.test'
 import { export1 , export2 as alias2 } from './lib/something'
+import { export1Test , export2 as alias2Test } from './lib/something.test'
 import { something } from './lib/something'
+import { somethingTest } from './lib/something.test'
 import { something as other } from './lib/something'
+import { something as otherTest } from './lib/something.test'
 import anotherImport from './lib/something'
+import anotherImportTest from './lib/something.test'
 import another, { otherImport } from './lib/something'
+import anotherTest, { otherImportTest } from './lib/something.test'
 import * as Something from './lib/something'
+import * as SomethingTest from './lib/something.test'
 import { transform } from '@babel/core'
 
 import { replacer_export1 , replacer_export2 as replacer_alias2 } from './lib/something.ts'
+import { replacer_export1Test , replacer_export2 as replacer_alias2Test } from './lib/something.test.ts'
 import { replacer_something } from './lib/something.ts'
+import { replacer_somethingTest } from './lib/something.test.ts'
 import { replacer_something as replacer_other } from './lib/something.ts'
+import { replacer_something as replacer_otherTest } from './lib/something.test.ts'
 import replacer_anotherImport from './lib/something.ts'
+import replacer_anotherImportTest from './lib/something.test.ts'
 import replacer_another, { replacer_otherImport } from './lib/something.ts'
+import replacer_anotherTest, { replacer_otherImportTest } from './lib/something.test.ts'
 import * as replacer_Something from './lib/something.ts'
+import * as replacer_SomethingTest from './lib/something.test.ts'
 `
+
 
 const exportStatements = `
 export { oneBackLevel } from '..'
@@ -31,42 +45,57 @@ export { oneBackLevelIndex } from '../'
 export { twoBackLevel } from '../..'
 export { twoBackLevelIndex } from '../../'
 export { somethingBack } from '../lib/something'
+export { somethingBackTest } from '../lib/something.test'
 export { something } from './lib/something'
+export { somethingTest } from './lib/something.test'
 export { something as another } from './lib/something'
+export { somethingTest as anotherTest } from './lib/something.test'
 export * as anotherModule from './lib/something'
+export * as anotherModuleTest from './lib/something.test'
 export * from './lib/something'
+export * from './lib/something.test'
 export { transform } from '@babel/core'
 
 export { replacer_something } from './lib/something.ts'
+export { replacer_somethingTest } from './lib/something.test.ts'
 export { replacer_something as replacer_another } from './lib/something.ts'
+export { replacer_something as replacer_anotherTest } from './lib/something.test.ts'
 export * as replacer_anotherModule from './lib/something.ts'
+export * as replacer_anotherModuleTest from './lib/something.test.ts'
 export * as replacer_something2 from './lib/something.ts'
+export * as replacer_something2Test from './lib/something.test.ts'
 `
 
 const typeOnlyExports = `
 export type { NamedType } from './lib/something'
+export type { NamedTypeTest } from './lib/something.test'
 `
 
 const typeOnlyImports = `
 import type DefaultType from './lib/something'
+import type DefaultTypeTest from './lib/something.test'
 import type { NamedType } from './lib/something'
+import type { NamedTypeTest } from './lib/something.test'
 import type * as AllTypes from './lib/something'
+import type * as AllTypesTest from './lib/something.test'
 `
 
 describe('Replace', () => {
   test.each`
-    type                                     | statements          | extension    | replace
-    ${'default extension to import'}         | ${importStatements} | ${undefined} | ${undefined}
-    ${'custom extension to import'}          | ${importStatements} | ${'jsx'}     | ${undefined}
-    ${'default extension to export'}         | ${exportStatements} | ${undefined} | ${undefined}
-    ${'custom extension to export'}          | ${exportStatements} | ${'jsx'}     | ${undefined}
-    ${'replace default extension to import'} | ${importStatements} | ${undefined} | ${true}
-    ${'replace custom extension to import'}  | ${importStatements} | ${'jsx'}     | ${true}
-    ${'replace default extension to export'} | ${exportStatements} | ${undefined} | ${true}
-    ${'replace custom extension to export'}  | ${exportStatements} | ${'jsx'}     | ${true}
-  `('should add the $type statements', ({ statements, extension, replace }) => {
+    type                                                  | statements          | extension    | replace      | observedScriptExtensions
+    ${'default extension to import'}                      | ${importStatements} | ${undefined} | ${undefined} | ${['js','ts','jsx','tsx']}
+    ${'custom extension to import'}                       | ${importStatements} | ${'jsx'}     | ${undefined} | ${['js','ts','jsx','tsx']}
+    ${'custom extension to import not observed'}          | ${importStatements} | ${'jsx'}     | ${undefined} | ${['js','ts','tsx']}
+    ${'custom extension to export'}                       | ${exportStatements} | ${'jsx'}     | ${undefined} | ${['js','ts','jsx','tsx']}
+    ${'custom extension to export not observed'}          | ${exportStatements} | ${'jsx'}     | ${undefined} | ${['js','ts','tsx']}
+    ${'replace default extension to import'}              | ${importStatements} | ${undefined} | ${true}      | ${['js','ts','jsx','tsx']}
+    ${'replace custom extension to import'}               | ${importStatements} | ${'jsx'}     | ${true}      | ${['js','ts','jsx','tsx']}
+    ${'replace custom extension to import not observed'}  | ${importStatements} | ${'jsx'}     | ${true}      | ${['js','ts','tsx']}
+    ${'replace custom extension to export'}               | ${exportStatements} | ${'jsx'}     | ${true}      | ${['js','ts','jsx','tsx']}
+    ${'replace custom extension to export not observed'}  | ${exportStatements} | ${'jsx'}     | ${true}      | ${['js','ts','tsx']}
+  `('should add the $type statements', ({ statements, extension, replace, observedScriptExtensions }) => {
     const { code } = babel.transformSync(statements, {
-      plugins: [[plugin, { extension, replace }]],
+      plugins: [[plugin, { extension, replace, observedScriptExtensions }]],
       filename: ''
     })
 
@@ -74,14 +103,16 @@ describe('Replace', () => {
   })
 
   test.each`
-    type                        | statements         | extension    | replace
-    ${'skip type-only imports'} | ${typeOnlyImports} | ${undefined} | ${undefined}
-    ${'skip type-only exports'} | ${typeOnlyExports} | ${undefined} | ${true}
-    ${'skip type-only imports'} | ${typeOnlyImports} | ${'jsx'}     | ${undefined}
-    ${'skip type-only exports'} | ${typeOnlyExports} | ${'jsx'}     | ${true}
-  `('should $type', ({ statements, extension, replace }) => {
+    type                                      | statements         | extension    | replace       | observedScriptExtensions
+    ${'skip type-only imports'}               | ${typeOnlyImports} | ${undefined} | ${undefined}  | ${['js','ts','jsx','tsx']}
+    ${'skip type-only exports'}               | ${typeOnlyExports} | ${undefined} | ${true}       | ${['js','ts','jsx','tsx']}
+    ${'skip type-only imports'}               | ${typeOnlyImports} | ${'jsx'}     | ${undefined}  | ${['js','ts','jsx','tsx']}
+    ${'skip type-only imports not observed'}  | ${typeOnlyImports} | ${'jsx'}     | ${undefined}  | ${['js','ts','tsx']}
+    ${'skip type-only exports'}               | ${typeOnlyExports} | ${'jsx'}     | ${true}       | ${['js','ts','jsx','tsx']}
+    ${'skip type-only exports not observed'}  | ${typeOnlyExports} | ${'jsx'}     | ${true}       | ${['js','ts','tsx']}
+  `('should $type', ({ statements, extension, replace, observedScriptExtensions }) => {
     const { code } = babel.transformSync(statements, {
-      plugins: [syntaxTypescript, [plugin, { extension, replace }]],
+      plugins: [syntaxTypescript, [plugin, { extension, replace, observedScriptExtensions }]],
       filename: ''
     })
 


### PR DESCRIPTION
Hello, 

I've had a go on a fix for issue #3. As all the `extname(module)` takes anything past the last `.` as extension I had to create an extension whitelist and filter at the right places to only take these for consideration. 

Hope that is of any help.
 
:)